### PR TITLE
remove redundant big-number conversions.

### DIFF
--- a/eth/contract.go
+++ b/eth/contract.go
@@ -193,7 +193,7 @@ func (contract *Contract) getHexValue(inputType string, value interface{}) (stri
 			}
 		}
 
-		data += fmt.Sprintf("%064s", fmt.Sprintf("%x", bigVal.String()))
+		data += fmt.Sprintf("%064s", bigVal.String())
 	}
 
 	if strings.Compare("address", inputType) == 0 {


### PR DESCRIPTION
There are redundant conversions. for example, the big-number is 1, we want a string like '000001', bigVal.string() return string '1', and fmt.Sprintf() convert it to '31', the final result is '000031', that's not we want. Just remove fmt.Sprintf(), it will work again.